### PR TITLE
fixed PlaylistCard responsive issue

### DIFF
--- a/src/components/PlaylistCard.jsx
+++ b/src/components/PlaylistCard.jsx
@@ -9,6 +9,8 @@ const PlaylistCard = ({ playlist, onRemove, onPlaylistClick }) => {
     }
   };
 
+  const playListTitle = `${playlist.title.slice(0, 50)}${playlist.title.length > 50 ? '...' : ''}`;
+
   return (
     <Card sx={{ display: 'flex', alignItems: 'center', mb: 2, p: 1 }}>
       <Link to={`/playlist/${playlist.id}`} onClick={handleClick}>
@@ -20,10 +22,10 @@ const PlaylistCard = ({ playlist, onRemove, onPlaylistClick }) => {
         />
       </Link>
       <Box sx={{ flex: 1 }}>
-        <Typography variant="h6" component={Link} to={`/playlist/${playlist.id}`} onClick={handleClick} sx={{ textDecoration: 'none', color: 'inherit' }}>
-          {playlist.title || 'Untitled Playlist'}
+        <Typography variant="h6" component={Link} to={`/playlist/${playlist.id}`} onClick={handleClick} sx={{ textDecoration: 'none', color: 'inherit', fontSize: { xs: '0.75rem', md: '1.25rem' } }}>
+          {playListTitle || 'Untitled Playlist'}
         </Typography>
-        <Typography variant="body2" color="text.secondary">
+        <Typography variant="body2" color="text.secondary" sx={{ fontSize: { xs: '0.65rem', md: '0.875rem' } }}>
           {playlist.channelTitle || 'Unknown Channel'}
         </Typography>
       </Box>


### PR DESCRIPTION
There was a slight problem that if the title of a playlist was too long, it would have to go to the saved playlist and favorite playlist to create a responsive issue on mobile. This has been resolved here.